### PR TITLE
Add Llama 3.2 1B/3B model support for cloud and embedded inference

### DIFF
--- a/Pages/SettingsPage.xaml
+++ b/Pages/SettingsPage.xaml
@@ -317,6 +317,27 @@
                                 HeightRequest="44"
                                 Clicked="OnDeleteEmbeddedModel"/>
                     </VerticalStackLayout>
+
+                    <!-- Embedded Agent Pipeline (multi-model) -->
+                    <VerticalStackLayout x:Name="EmbeddedPipelinePanel" Spacing="12" IsVisible="False">
+                        <HorizontalStackLayout Spacing="8">
+                            <Label Text="&#xf544;" 
+                                   FontFamily="FontAwesomeSolid" 
+                                   FontSize="16" 
+                                   TextColor="{StaticResource Nord13}"
+                                   VerticalOptions="Center"/>
+                            <Label Text="Embedded Agent Pipeline"
+                                   FontSize="14" 
+                                   FontAttributes="Bold"
+                                   TextColor="{AppThemeBinding Light={StaticResource Nord3}, Dark={StaticResource Nord4}}"/>
+                        </HorizontalStackLayout>
+                        <Label Text="Apple Intelligence (researcher) → Llama 3.2 3B (writer) → Llama 3.2 1B (editor). Download both Llama models in Embedded ONNX mode." 
+                               FontSize="12" 
+                               TextColor="{StaticResource Nord3}"/>
+                        <Label x:Name="EmbeddedPipelineStatusLabel"
+                               FontSize="14" 
+                               TextColor="{AppThemeBinding Light={StaticResource Nord3}, Dark={StaticResource Nord4}}"/>
+                    </VerticalStackLayout>
                 </VerticalStackLayout>
             </Border>
 

--- a/Pages/SettingsPage.xaml
+++ b/Pages/SettingsPage.xaml
@@ -279,6 +279,17 @@
                         <Label Text="Run a full language model entirely on-device using ONNX Runtime GenAI. No server, no internet, full privacy." 
                                FontSize="12" 
                                TextColor="{StaticResource Nord3}"/>
+                        <HorizontalStackLayout Spacing="8">
+                            <Label Text="Model" 
+                                   FontSize="14" 
+                                   TextColor="{AppThemeBinding Light={StaticResource Nord3}, Dark={StaticResource Nord4}}"
+                                   VerticalOptions="Center"/>
+                            <Picker x:Name="EmbeddedModelPicker"
+                                    WidthRequest="280"
+                                    TextColor="{AppThemeBinding Light={StaticResource Nord0}, Dark={StaticResource Nord6}}"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource Nord4}, Dark={StaticResource Nord2}}"
+                                    SelectedIndexChanged="OnEmbeddedModelPickerChanged"/>
+                        </HorizontalStackLayout>
                         <Label x:Name="EmbeddedModelStatusLabel"
                                FontSize="14" 
                                TextColor="{AppThemeBinding Light={StaticResource Nord3}, Dark={StaticResource Nord4}}"/>

--- a/Pages/SettingsPage.xaml.cs
+++ b/Pages/SettingsPage.xaml.cs
@@ -115,6 +115,7 @@ public partial class SettingsPage : ContentPage
         PipelineSettingsPanel.IsVisible = ExcuseService.CurrentMode == "pipeline";
         CustomEndpointPanel.IsVisible = ExcuseService.CurrentMode == "custom";
         EmbeddedModelPanel.IsVisible = ExcuseService.CurrentMode == "embedded";
+        EmbeddedPipelinePanel.IsVisible = ExcuseService.CurrentMode == "embedded_pipeline";
         
         if (ExcuseService.CurrentMode == "ondevice")
         {
@@ -127,6 +128,10 @@ public partial class SettingsPage : ContentPage
         if (ExcuseService.CurrentMode == "embedded")
         {
             UpdateEmbeddedModelStatus();
+        }
+        if (ExcuseService.CurrentMode == "embedded_pipeline")
+        {
+            UpdateEmbeddedPipelineStatus();
         }
     }
 
@@ -310,5 +315,24 @@ public partial class SettingsPage : ContentPage
         OnnxGenAIChatClient.UnloadCached();
         OnnxModelManager.DeleteModel(model.Id);
         UpdateEmbeddedModelStatus();
+    }
+
+    // -- Embedded Agent Pipeline --
+
+    private void UpdateEmbeddedPipelineStatus()
+    {
+        var llama3b = OnnxModelManager.IsModelDownloaded("llama-3.2-3b-int4");
+        var llama1b = OnnxModelManager.IsModelDownloaded("llama-3.2-1b-int4");
+        var aiAvail = _excuseService.IsOnDeviceAvailable;
+
+        var status = new List<string>();
+        status.Add(aiAvail ? "✅ Apple Intelligence" : "❌ Apple Intelligence");
+        status.Add(llama3b ? "✅ Llama 3.2 3B" : "❌ Llama 3.2 3B");
+        status.Add(llama1b ? "✅ Llama 3.2 1B" : "❌ Llama 3.2 1B");
+
+        EmbeddedPipelineStatusLabel.Text = string.Join("  ·  ", status);
+        EmbeddedPipelineStatusLabel.TextColor = (aiAvail && llama3b && llama1b)
+            ? Color.FromArgb("#A3BE8C")
+            : Color.FromArgb("#D08770");
     }
 }

--- a/Pages/SettingsPage.xaml.cs
+++ b/Pages/SettingsPage.xaml.cs
@@ -7,6 +7,8 @@ public partial class SettingsPage : ContentPage
     private static readonly string[] GroqModels = 
     {
         "llama-3.3-70b-versatile",
+        "llama-3.2-3b-preview",
+        "llama-3.2-1b-preview",
         "llama-3.1-8b-instant",
         "gemma2-9b-it"
     };
@@ -209,9 +211,24 @@ public partial class SettingsPage : ContentPage
 
     private CancellationTokenSource? _downloadCts;
 
+    private OnnxModelInfo SelectedEmbeddedModel =>
+        OnnxModelManager.AvailableModels[
+            Math.Max(0, Math.Min(EmbeddedModelPicker.SelectedIndex, OnnxModelManager.AvailableModels.Length - 1))];
+
     private void UpdateEmbeddedModelStatus()
     {
-        var model = OnnxModelManager.AvailableModels[0];
+        // Populate picker if empty
+        if (EmbeddedModelPicker.Items.Count == 0)
+        {
+            foreach (var m in OnnxModelManager.AvailableModels)
+                EmbeddedModelPicker.Items.Add(m.Name);
+
+            var savedId = Preferences.Get("EmbeddedOnnxModelId", "phi3-mini-int4");
+            var idx = Array.FindIndex(OnnxModelManager.AvailableModels, m => m.Id == savedId);
+            EmbeddedModelPicker.SelectedIndex = idx >= 0 ? idx : 0;
+        }
+
+        var model = SelectedEmbeddedModel;
         if (OnnxModelManager.IsModelDownloaded(model.Id))
         {
             var size = OnnxModelManager.GetDownloadedSize(model.Id);
@@ -232,9 +249,17 @@ public partial class SettingsPage : ContentPage
         }
     }
 
+    private void OnEmbeddedModelPickerChanged(object? sender, EventArgs e)
+    {
+        if (EmbeddedModelPicker.SelectedIndex < 0) return;
+        var model = SelectedEmbeddedModel;
+        Preferences.Set("EmbeddedOnnxModelId", model.Id);
+        UpdateEmbeddedModelStatus();
+    }
+
     private async void OnDownloadEmbeddedModel(object? sender, EventArgs e)
     {
-        var model = OnnxModelManager.AvailableModels[0];
+        var model = SelectedEmbeddedModel;
         _downloadCts?.Cancel();
         _downloadCts = new CancellationTokenSource();
 
@@ -275,12 +300,13 @@ public partial class SettingsPage : ContentPage
 
     private async void OnDeleteEmbeddedModel(object? sender, EventArgs e)
     {
+        var model = SelectedEmbeddedModel;
+        var sizeGB = model.EstimatedSizeBytes / (1024.0 * 1024 * 1024);
         var confirm = await DisplayAlert("Delete Model",
-            "Delete the downloaded ONNX model? This frees ~2.5 GB of storage.",
+            $"Delete the downloaded {model.Name}? This frees ~{sizeGB:F1} GB of storage.",
             "Delete", "Cancel");
         if (!confirm) return;
 
-        var model = OnnxModelManager.AvailableModels[0];
 #if !IOS
         OnnxGenAIChatClient.UnloadCached();
 #endif

--- a/Pages/SettingsPage.xaml.cs
+++ b/Pages/SettingsPage.xaml.cs
@@ -307,9 +307,7 @@ public partial class SettingsPage : ContentPage
             "Delete", "Cancel");
         if (!confirm) return;
 
-#if !IOS
         OnnxGenAIChatClient.UnloadCached();
-#endif
         OnnxModelManager.DeleteModel(model.Id);
         UpdateEmbeddedModelStatus();
     }

--- a/Platforms/iOS/OrtExtensionsStub.c
+++ b/Platforms/iOS/OrtExtensionsStub.c
@@ -1,0 +1,9 @@
+// Stub for ONNX Runtime custom ops registration required when statically linking on iOS.
+// ORT calls this symbol at session init; returning NULL means no custom ops to register.
+typedef struct OrtSessionOptions OrtSessionOptions;
+typedef struct OrtApiBase OrtApiBase;
+typedef struct OrtStatus OrtStatus;
+
+OrtStatus* RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api_base) {
+    return (OrtStatus*)0;
+}

--- a/Services/EmbeddedAgentPipelineExcuseGenerator.cs
+++ b/Services/EmbeddedAgentPipelineExcuseGenerator.cs
@@ -60,10 +60,10 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
             OnStageChanged?.Invoke("🔍 Apple Intelligence: Researching...");
             var researchMessages = new List<ChatMessage>
             {
-                new(ChatRole.System, "You are a creative comedy researcher. Your job is to come up with a detailed absurd scenario that could be used as an excuse for not doing work. Be specific with names, places, and events. Output 3-5 sentences describing the scenario vividly."),
-                new(ChatRole.User, $"Come up with a bizarre, funny, and detailed scenario involving {GetRandomElement()}. Include specific details like names, locations, and consequences. Describe what happened step by step. Be wildly creative and specific.")
+                new(ChatRole.User, $"You are a creative comedy researcher. Come up with a bizarre, funny, and detailed scenario involving {GetRandomElement()} that could be used as an excuse for not doing work. Include specific details like names, locations, and consequences. Describe what happened step by step in 3-5 sentences. Be wildly creative and specific.")
             };
-            var researchResponse = await _onDeviceChatClient.GetResponseAsync(researchMessages);
+            using var researchCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var researchResponse = await _onDeviceChatClient.GetResponseAsync(researchMessages, cancellationToken: researchCts.Token);
             var scenario = researchResponse.Text?.Trim() ?? "";
             OnAgentOutput?.Invoke("🔍 Apple Intelligence", scenario);
 

--- a/Services/EmbeddedAgentPipelineExcuseGenerator.cs
+++ b/Services/EmbeddedAgentPipelineExcuseGenerator.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using Microsoft.Extensions.AI;
+
+namespace procrastinate.Services;
+
+/// <summary>
+/// Multi-agent pipeline using Apple Intelligence for research and embedded ONNX models for writing/editing:
+/// Apple Intelligence (researcher) → Llama 3.2 3B (writer) → Llama 3.2 1B (editor).
+/// </summary>
+public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
+{
+    private const string WriterModelId = "llama-3.2-3b-int4";
+    private const string EditorModelId = "llama-3.2-1b-int4";
+
+    private readonly IChatClient? _onDeviceChatClient;
+
+    public string Name => "Embedded Agent Pipeline";
+
+    public bool IsAvailable =>
+        _onDeviceChatClient is not null &&
+        OnnxModelManager.IsModelDownloaded(WriterModelId) &&
+        OnnxModelManager.IsModelDownloaded(EditorModelId);
+
+    public Action<string>? OnStageChanged { get; set; }
+    public Action<string, string>? OnAgentOutput { get; set; }
+
+    public EmbeddedAgentPipelineExcuseGenerator(IChatClient? onDeviceChatClient = null)
+    {
+        _onDeviceChatClient = onDeviceChatClient;
+    }
+
+    public async Task<ExcuseResult> GenerateExcuseAsync(string language)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        if (_onDeviceChatClient is null)
+        {
+            stopwatch.Stop();
+            return new ExcuseResult(
+                "Apple Intelligence is required for the researcher agent. Use a device with iOS 18.4+.",
+                Name, stopwatch.Elapsed);
+        }
+
+        if (!OnnxModelManager.IsModelDownloaded(WriterModelId) || !OnnxModelManager.IsModelDownloaded(EditorModelId))
+        {
+            var missing = new List<string>();
+            if (!OnnxModelManager.IsModelDownloaded(WriterModelId)) missing.Add("Llama 3.2 3B");
+            if (!OnnxModelManager.IsModelDownloaded(EditorModelId)) missing.Add("Llama 3.2 1B");
+            stopwatch.Stop();
+            return new ExcuseResult(
+                $"Download models in Settings → Embedded ONNX: {string.Join(", ", missing)}",
+                Name, stopwatch.Elapsed);
+        }
+
+        try
+        {
+            var languageName = GetLanguageName(language);
+
+            // Agent 1: Researcher (Apple Intelligence) — picks an absurd scenario
+            OnStageChanged?.Invoke("🔍 Apple Intelligence: Researching...");
+            var researchMessages = new List<ChatMessage>
+            {
+                new(ChatRole.System, "You are a creative comedy researcher. Your job is to come up with an absurd, unexpected scenario that could be used as an excuse. Output ONLY the scenario in 1-2 sentences. Be wildly creative."),
+                new(ChatRole.User, $"Come up with a bizarre, funny scenario involving {GetRandomElement()}. Make it unexpected and absurd. Just the scenario, nothing else.")
+            };
+            var researchResponse = await _onDeviceChatClient.GetResponseAsync(researchMessages);
+            var scenario = researchResponse.Text?.Trim() ?? "";
+            OnAgentOutput?.Invoke("🔍 Apple Intelligence", scenario);
+
+            // Agent 2: Writer (Llama 3.2 3B) — crafts the excuse
+            OnStageChanged?.Invoke("✍️ Llama 3B: Writing...");
+            var rawExcuse = await RunAgentAsync(WriterModelId,
+                "You are a comedy writer. You turn scenarios into first-person excuses that sound like something a real person would say. Keep it to 1-2 sentences. Start with 'I' or 'Sorry'.",
+                $"Turn this scenario into a funny first-person excuse in {languageName}:\n\n{scenario}\n\nJust the excuse, nothing else.");
+            OnAgentOutput?.Invoke("✍️ Llama 3B Writer", rawExcuse);
+
+            // Agent 3: Editor (Llama 3.2 1B) — polishes
+            OnStageChanged?.Invoke("✨ Llama 1B: Polishing...");
+            var finalExcuse = await RunAgentAsync(EditorModelId,
+                $"You are a comedy editor. You polish excuses to be funnier and more natural-sounding. Keep the same language ({languageName}). Output ONLY the polished excuse.",
+                $"Polish this excuse to be funnier and more natural. Keep it in {languageName}. Keep it to 1-2 sentences:\n\n{rawExcuse}\n\nJust the polished excuse, nothing else.");
+            OnAgentOutput?.Invoke("✨ Llama 1B Editor", finalExcuse.Trim());
+
+            OnStageChanged?.Invoke("✅ Done!");
+            stopwatch.Stop();
+
+            return new ExcuseResult(
+                finalExcuse.Trim(),
+                Name,
+                stopwatch.Elapsed,
+                Model: "Apple Intelligence → Llama 3B → Llama 1B");
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            Debug.WriteLine($"Embedded pipeline error: {ex}");
+            return new ExcuseResult($"Embedded pipeline error: {ex.Message}", Name, stopwatch.Elapsed);
+        }
+    }
+
+    private static async Task<string> RunAgentAsync(string modelId, string systemPrompt, string userPrompt)
+    {
+        var modelPath = OnnxModelManager.GetModelDirectory(modelId);
+        var modelInfo = OnnxModelManager.AvailableModels.First(m => m.Id == modelId);
+        var client = OnnxGenAIChatClient.GetOrCreate(modelPath, modelInfo.Name);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userPrompt)
+        };
+
+        var response = await client.GetResponseAsync(messages, new ChatOptions
+        {
+            MaxOutputTokens = 150,
+            Temperature = 0.9f
+        });
+
+        return response.Text?.Trim() ?? "";
+    }
+
+    private static string GetRandomElement()
+    {
+        var elements = new[]
+        {
+            "a time-traveling pigeon", "sentient office furniture", "a secret society of squirrels",
+            "a parallel universe where gravity is optional", "a conspiracy involving socks",
+            "an AI that became a life coach", "a haunted coffee machine", "quantum entangled twins",
+            "a diplomatic incident with a penguin", "a rogue weather satellite",
+            "an enchanted parking meter", "a philosophical debate with a cat",
+            "a mysterious portal in the closet", "an accidental invention", "a cursed alarm clock",
+            "a runaway sourdough starter", "an overly helpful robot vacuum",
+            "a neighborhood raccoon uprising", "a telepathic houseplant", "a glitch in spacetime"
+        };
+        return elements[Random.Shared.Next(elements.Length)];
+    }
+
+    private static string GetLanguageName(string language) => language switch
+    {
+        "fr" => "French",
+        "es" => "Spanish",
+        "pt" => "Portuguese",
+        "nl" => "Dutch",
+        "cs" => "Czech",
+        "uk" => "Ukrainian",
+        _ => "English"
+    };
+}

--- a/Services/EmbeddedAgentPipelineExcuseGenerator.cs
+++ b/Services/EmbeddedAgentPipelineExcuseGenerator.cs
@@ -60,25 +60,28 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
             OnStageChanged?.Invoke("🔍 Apple Intelligence: Researching...");
             var researchMessages = new List<ChatMessage>
             {
-                new(ChatRole.User, $"You are a creative comedy researcher. Come up with a bizarre, funny, and detailed scenario involving {GetRandomElement()} that could be used as an excuse for not doing work. Include specific details like names, locations, and consequences. Describe what happened step by step in 3-5 sentences. Be wildly creative and specific.")
+                new(ChatRole.User, $"Come up with one short bizarre funny scenario involving {GetRandomElement()} as an excuse for not working. Maximum 2 sentences.")
             };
             using var researchCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var researchResponse = await _onDeviceChatClient.GetResponseAsync(researchMessages, cancellationToken: researchCts.Token);
             var scenario = researchResponse.Text?.Trim() ?? "";
+            // Truncate to keep within Llama's context window
+            if (scenario.Length > 300)
+                scenario = scenario[..300];
             OnAgentOutput?.Invoke("🔍 Apple Intelligence", scenario);
 
             // Agent 2: Writer (Llama 3.2 3B) — crafts the excuse
             OnStageChanged?.Invoke("✍️ Llama 3B: Writing...");
             var rawExcuse = await RunAgentAsync(WriterModelId,
-                "You are a comedy writer who turns scenarios into hilarious first-person excuses. You must incorporate the key details from the scenario provided. Write a natural-sounding excuse in 2-3 sentences.",
-                $"Here is a detailed scenario that happened to me:\n\n\"{scenario}\"\n\nUsing ALL the key details from that scenario, write a funny first-person excuse in {languageName} explaining why I can't do work today. Start with 'Sorry' or 'I can't' and reference the specific details from the scenario.");
+                "You turn scenarios into short funny first-person excuses. 1-2 sentences max.",
+                $"Scenario: {scenario}\n\nWrite a funny excuse in {languageName} based on that. Start with 'Sorry'. 1-2 sentences only.");
             OnAgentOutput?.Invoke("✍️ Llama 3B Writer", rawExcuse);
 
             // Agent 3: Editor (Llama 3.2 1B) — polishes
             OnStageChanged?.Invoke("✨ Llama 1B: Polishing...");
             var finalExcuse = await RunAgentAsync(EditorModelId,
-                $"You are a comedy editor. You polish excuses to be funnier and more natural-sounding. Keep the same language ({languageName}). Output ONLY the polished excuse.",
-                $"Polish this excuse to be funnier and more natural. Keep it in {languageName}. Keep it to 1-2 sentences:\n\n{rawExcuse}\n\nJust the polished excuse, nothing else.");
+                "You polish excuses to be funnier. Keep it short. Same language.",
+                $"Polish this excuse in {languageName}, keep 1-2 sentences:\n\n{rawExcuse}");
             OnAgentOutput?.Invoke("✨ Llama 1B Editor", finalExcuse.Trim());
 
             OnStageChanged?.Invoke("✅ Done!");

--- a/Services/EmbeddedAgentPipelineExcuseGenerator.cs
+++ b/Services/EmbeddedAgentPipelineExcuseGenerator.cs
@@ -60,8 +60,8 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
             OnStageChanged?.Invoke("🔍 Apple Intelligence: Researching...");
             var researchMessages = new List<ChatMessage>
             {
-                new(ChatRole.System, "You are a creative comedy researcher. Your job is to come up with an absurd, unexpected scenario that could be used as an excuse. Output ONLY the scenario in 1-2 sentences. Be wildly creative."),
-                new(ChatRole.User, $"Come up with a bizarre, funny scenario involving {GetRandomElement()}. Make it unexpected and absurd. Just the scenario, nothing else.")
+                new(ChatRole.System, "You are a creative comedy researcher. Your job is to come up with a detailed absurd scenario that could be used as an excuse for not doing work. Be specific with names, places, and events. Output 3-5 sentences describing the scenario vividly."),
+                new(ChatRole.User, $"Come up with a bizarre, funny, and detailed scenario involving {GetRandomElement()}. Include specific details like names, locations, and consequences. Describe what happened step by step. Be wildly creative and specific.")
             };
             var researchResponse = await _onDeviceChatClient.GetResponseAsync(researchMessages);
             var scenario = researchResponse.Text?.Trim() ?? "";
@@ -70,8 +70,8 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
             // Agent 2: Writer (Llama 3.2 3B) — crafts the excuse
             OnStageChanged?.Invoke("✍️ Llama 3B: Writing...");
             var rawExcuse = await RunAgentAsync(WriterModelId,
-                "You are a comedy writer. You turn scenarios into first-person excuses that sound like something a real person would say. Keep it to 1-2 sentences. Start with 'I' or 'Sorry'.",
-                $"Turn this scenario into a funny first-person excuse in {languageName}:\n\n{scenario}\n\nJust the excuse, nothing else.");
+                "You are a comedy writer who turns scenarios into hilarious first-person excuses. You must incorporate the key details from the scenario provided. Write a natural-sounding excuse in 2-3 sentences.",
+                $"Here is a detailed scenario that happened to me:\n\n\"{scenario}\"\n\nUsing ALL the key details from that scenario, write a funny first-person excuse in {languageName} explaining why I can't do work today. Start with 'Sorry' or 'I can't' and reference the specific details from the scenario.");
             OnAgentOutput?.Invoke("✍️ Llama 3B Writer", rawExcuse);
 
             // Agent 3: Editor (Llama 3.2 1B) — polishes
@@ -102,7 +102,7 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
     {
         var modelPath = OnnxModelManager.GetModelDirectory(modelId);
         var modelInfo = OnnxModelManager.AvailableModels.First(m => m.Id == modelId);
-        var client = OnnxGenAIChatClient.GetOrCreate(modelPath, modelInfo.Name);
+        var client = OnnxGenAIChatClient.GetOrCreate(modelPath, modelInfo.Name, modelInfo.Template);
 
         var messages = new List<ChatMessage>
         {
@@ -112,7 +112,7 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
 
         var response = await client.GetResponseAsync(messages, new ChatOptions
         {
-            MaxOutputTokens = 150,
+            MaxOutputTokens = 256,
             Temperature = 0.9f
         });
 

--- a/Services/EmbeddedAgentPipelineExcuseGenerator.cs
+++ b/Services/EmbeddedAgentPipelineExcuseGenerator.cs
@@ -60,7 +60,7 @@ public class EmbeddedAgentPipelineExcuseGenerator : IExcuseGenerator
             OnStageChanged?.Invoke("🔍 Apple Intelligence: Researching...");
             var researchMessages = new List<ChatMessage>
             {
-                new(ChatRole.User, $"Come up with one short bizarre funny scenario involving {GetRandomElement()} as an excuse for not working. Maximum 2 sentences.")
+                new(ChatRole.User, $"Write a short funny fictional story about {GetRandomElement()}. Make it silly and absurd. Maximum 2 sentences.")
             };
             using var researchCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var researchResponse = await _onDeviceChatClient.GetResponseAsync(researchMessages, cancellationToken: researchCts.Token);

--- a/Services/EmbeddedModelExcuseGenerator.cs
+++ b/Services/EmbeddedModelExcuseGenerator.cs
@@ -13,9 +13,9 @@ public class EmbeddedModelExcuseGenerator : IExcuseGenerator
 
     public string Name => "Embedded ONNX AI";
 
-    public EmbeddedModelExcuseGenerator(string modelId = "phi3-mini-int4")
+    public EmbeddedModelExcuseGenerator(string? modelId = null)
     {
-        _modelId = modelId;
+        _modelId = modelId ?? Preferences.Get("EmbeddedOnnxModelId", "phi3-mini-int4");
     }
 
 #if IOS

--- a/Services/EmbeddedModelExcuseGenerator.cs
+++ b/Services/EmbeddedModelExcuseGenerator.cs
@@ -5,7 +5,6 @@ namespace procrastinate.Services;
 
 /// <summary>
 /// Generates excuses using an embedded ONNX model running entirely on-device.
-/// On iOS, this is not available (use Apple Intelligence instead); works on Android/macCatalyst.
 /// </summary>
 public class EmbeddedModelExcuseGenerator : IExcuseGenerator
 {
@@ -18,16 +17,6 @@ public class EmbeddedModelExcuseGenerator : IExcuseGenerator
         _modelId = modelId ?? Preferences.Get("EmbeddedOnnxModelId", "phi3-mini-int4");
     }
 
-#if IOS
-    public bool IsAvailable => false;
-
-    public Task<ExcuseResult> GenerateExcuseAsync(string language)
-    {
-        return Task.FromResult(new ExcuseResult(
-            "Embedded ONNX model is not available on iOS. Use Apple Intelligence instead!",
-            Name, TimeSpan.Zero));
-    }
-#else
     public bool IsAvailable => OnnxModelManager.IsModelDownloaded(_modelId);
 
     public async Task<ExcuseResult> GenerateExcuseAsync(string language)
@@ -82,5 +71,4 @@ public class EmbeddedModelExcuseGenerator : IExcuseGenerator
             return new ExcuseResult($"Error running embedded model: {ex.Message}", Name, stopwatch.Elapsed);
         }
     }
-#endif
 }

--- a/Services/EmbeddedModelExcuseGenerator.cs
+++ b/Services/EmbeddedModelExcuseGenerator.cs
@@ -36,7 +36,7 @@ public class EmbeddedModelExcuseGenerator : IExcuseGenerator
 
         try
         {
-            var client = OnnxGenAIChatClient.GetOrCreate(modelPath, modelInfo.Name);
+            var client = OnnxGenAIChatClient.GetOrCreate(modelPath, modelInfo.Name, modelInfo.Template);
 
             var topic = OnDeviceAIExcuseGenerator.RandomTopics[
                 Random.Shared.Next(OnDeviceAIExcuseGenerator.RandomTopics.Length)];

--- a/Services/ExcuseService.cs
+++ b/Services/ExcuseService.cs
@@ -50,7 +50,9 @@ public class ExcuseService
 #endif
             modes.Add("pipeline", "🤖 AI Agent Pipeline (3 agents)");
             modes.Add("custom", "Custom Endpoint (BYOM)");
+#if !IOS
             modes.Add("embedded", "📦 Embedded ONNX Model (offline)");
+#endif
             return modes;
         }
     }

--- a/Services/ExcuseService.cs
+++ b/Services/ExcuseService.cs
@@ -51,6 +51,7 @@ public class ExcuseService
             modes.Add("pipeline", "🤖 AI Agent Pipeline (3 agents)");
             modes.Add("custom", "Custom Endpoint (BYOM)");
             modes.Add("embedded", "📦 Embedded ONNX Model (offline)");
+            modes.Add("embedded_pipeline", "🧠 Embedded Agent Pipeline (3 models)");
             return modes;
         }
     }
@@ -74,6 +75,7 @@ public class ExcuseService
             "pipeline" => new AgentPipelineExcuseGenerator(_onDeviceChatClient) { OnStageChanged = OnPipelineStageChanged, OnAgentOutput = OnAgentOutput },
             "custom" => new CustomEndpointExcuseGenerator(),
             "embedded" => new EmbeddedModelExcuseGenerator(),
+            "embedded_pipeline" => new EmbeddedAgentPipelineExcuseGenerator(_onDeviceChatClient) { OnStageChanged = OnPipelineStageChanged, OnAgentOutput = OnAgentOutput },
             _ => _randomGenerator
         };
     }

--- a/Services/ExcuseService.cs
+++ b/Services/ExcuseService.cs
@@ -50,9 +50,7 @@ public class ExcuseService
 #endif
             modes.Add("pipeline", "🤖 AI Agent Pipeline (3 agents)");
             modes.Add("custom", "Custom Endpoint (BYOM)");
-#if !IOS
             modes.Add("embedded", "📦 Embedded ONNX Model (offline)");
-#endif
             return modes;
         }
     }

--- a/Services/OnnxGenAIChatClient.cs
+++ b/Services/OnnxGenAIChatClient.cs
@@ -13,6 +13,7 @@ public class OnnxGenAIChatClient : IChatClient
 {
     private readonly Model _model;
     private readonly Tokenizer _tokenizer;
+    private readonly ChatTemplate _template;
     private bool _disposed;
 
     public ChatClientMetadata Metadata { get; }
@@ -22,7 +23,7 @@ public class OnnxGenAIChatClient : IChatClient
     private static string? _cachedPath;
     private static int _activeInferences;
 
-    public static OnnxGenAIChatClient GetOrCreate(string modelPath, string modelName = "ONNX Local")
+    public static OnnxGenAIChatClient GetOrCreate(string modelPath, string modelName = "ONNX Local", ChatTemplate template = ChatTemplate.Phi3)
     {
         lock (_lock)
         {
@@ -34,7 +35,7 @@ public class OnnxGenAIChatClient : IChatClient
                 _cached.DisposeInternal();
             }
 
-            _cached = new OnnxGenAIChatClient(modelPath, modelName);
+            _cached = new OnnxGenAIChatClient(modelPath, modelName, template);
             _cachedPath = modelPath;
             return _cached;
         }
@@ -53,10 +54,11 @@ public class OnnxGenAIChatClient : IChatClient
         }
     }
 
-    private OnnxGenAIChatClient(string modelPath, string modelName)
+    private OnnxGenAIChatClient(string modelPath, string modelName, ChatTemplate template)
     {
         _model = new Model(modelPath);
         _tokenizer = new Tokenizer(_model);
+        _template = template;
         Metadata = new ChatClientMetadata("OnnxRuntimeGenAI");
     }
 
@@ -72,7 +74,7 @@ public class OnnxGenAIChatClient : IChatClient
             {
                 if (_disposed) throw new ObjectDisposedException(nameof(OnnxGenAIChatClient));
 
-                var prompt = FormatChatPrompt(chatMessages);
+                var prompt = FormatChatPrompt(chatMessages, _template);
                 using var sequences = _tokenizer.Encode(prompt);
 
                 using var genParams = new GeneratorParams(_model);
@@ -126,24 +128,39 @@ public class OnnxGenAIChatClient : IChatClient
         _model?.Dispose();
     }
 
-    private static string FormatChatPrompt(IEnumerable<ChatMessage> messages)
+    private static string FormatChatPrompt(IEnumerable<ChatMessage> messages, ChatTemplate template)
     {
         var sb = new StringBuilder();
-        foreach (var msg in messages)
+        if (template == ChatTemplate.Llama3)
         {
-            var role = msg.Role == ChatRole.System ? "system"
-                     : msg.Role == ChatRole.User ? "user"
-                     : "assistant";
-            sb.Append($"<|{role}|>\n{msg.Text}<|end|>\n");
+            sb.Append("<|begin_of_text|>");
+            foreach (var msg in messages)
+            {
+                var role = msg.Role == ChatRole.System ? "system"
+                         : msg.Role == ChatRole.User ? "user"
+                         : "assistant";
+                sb.Append($"<|start_header_id|>{role}<|end_header_id|>\n\n{msg.Text}<|eot_id|>");
+            }
+            sb.Append("<|start_header_id|>assistant<|end_header_id|>\n\n");
         }
-        sb.Append("<|assistant|>\n");
+        else
+        {
+            foreach (var msg in messages)
+            {
+                var role = msg.Role == ChatRole.System ? "system"
+                         : msg.Role == ChatRole.User ? "user"
+                         : "assistant";
+                sb.Append($"<|{role}|>\n{msg.Text}<|end|>\n");
+            }
+            sb.Append("<|assistant|>\n");
+        }
         return sb.ToString();
     }
 
     private static string CleanOutput(string text)
     {
         text = text.Trim();
-        foreach (var marker in new[] { "<|end|>", "<|endoftext|>", "<|assistant|>" })
+        foreach (var marker in new[] { "<|end|>", "<|endoftext|>", "<|assistant|>", "<|eot_id|>", "<|end_of_text|>" })
         {
             var idx = text.IndexOf(marker, StringComparison.Ordinal);
             if (idx >= 0) text = text[..idx].Trim();

--- a/Services/OnnxGenAIChatClient.cs
+++ b/Services/OnnxGenAIChatClient.cs
@@ -1,4 +1,3 @@
-#if !IOS
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.AI;
@@ -117,6 +116,8 @@ public class OnnxGenAIChatClient : IChatClient
     public object? GetService(Type serviceType, object? key = null)
         => serviceType.IsAssignableFrom(GetType()) ? this : null;
 
+    public void Dispose() => DisposeInternal();
+
     private void DisposeInternal()
     {
         if (_disposed) return;
@@ -150,4 +151,3 @@ public class OnnxGenAIChatClient : IChatClient
         return text;
     }
 }
-#endif

--- a/Services/OnnxModelManager.cs
+++ b/Services/OnnxModelManager.cs
@@ -7,22 +7,31 @@ public record OnnxModelInfo(
     string Name,
     string HuggingFaceRepo,
     string SubFolder,
-    long EstimatedSizeBytes);
+    long EstimatedSizeBytes,
+    string PinnedRevision);
 
 public class OnnxModelManager
 {
     private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromMinutes(60) };
     private static readonly SemaphoreSlim _downloadLock = new(1, 1);
 
-    // Pinned commit SHA for reproducible downloads
-    private const string PinnedRevision = "4afb4415e36dbe8f2a1165e30ac4e4b10d2f29dd";
-
     public static readonly OnnxModelInfo[] AvailableModels =
     [
         new("phi3-mini-int4", "Phi-3 Mini INT4 (2.5 GB)",
             "microsoft/Phi-3-mini-4k-instruct-onnx",
             "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
-            2_725_535_000L)
+            2_725_535_000L,
+            "4afb4415e36dbe8f2a1165e30ac4e4b10d2f29dd"),
+        new("llama-3.2-1b-int4", "Llama 3.2 1B INT4 (1.7 GB)",
+            "onnx-community/Llama-3.2-1B-Instruct-GENAI-ONNX",
+            "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
+            1_866_090_000L,
+            "e983c740a38fcfa57fb4d124b18b644974c3d966"),
+        new("llama-3.2-3b-int4", "Llama 3.2 3B INT4 (3.4 GB)",
+            "onnx-community/Llama-3.2-3B-Instruct-GENAI-ONNX",
+            "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
+            3_661_007_000L,
+            "5db5cdb5b0c8c440264ca0f16f5ec3351e753add")
     ];
 
     public static string GetModelDirectory(string modelId)
@@ -55,7 +64,7 @@ public class OnnxModelManager
             Directory.CreateDirectory(modelDir);
 
             // List files from HuggingFace API (pinned revision)
-            var apiUrl = $"https://huggingface.co/api/models/{model.HuggingFaceRepo}/tree/{PinnedRevision}/{model.SubFolder}";
+            var apiUrl = $"https://huggingface.co/api/models/{model.HuggingFaceRepo}/tree/{model.PinnedRevision}/{model.SubFolder}";
             var json = await _httpClient.GetStringAsync(apiUrl, ct);
             var entries = JsonSerializer.Deserialize<JsonElement[]>(json) ?? [];
 
@@ -89,7 +98,7 @@ public class OnnxModelManager
                     continue;
                 }
 
-                var url = $"https://huggingface.co/{model.HuggingFaceRepo}/resolve/{PinnedRevision}/{model.SubFolder}/{name}";
+                var url = $"https://huggingface.co/{model.HuggingFaceRepo}/resolve/{model.PinnedRevision}/{model.SubFolder}/{name}";
                 progress?.Report((downloaded, totalSize, $"⬇ {name}"));
 
                 var tmpPath = filePath + ".tmp";

--- a/Services/OnnxModelManager.cs
+++ b/Services/OnnxModelManager.cs
@@ -2,13 +2,16 @@ using System.Text.Json;
 
 namespace procrastinate.Services;
 
+public enum ChatTemplate { Phi3, Llama3 }
+
 public record OnnxModelInfo(
     string Id,
     string Name,
     string HuggingFaceRepo,
     string SubFolder,
     long EstimatedSizeBytes,
-    string PinnedRevision);
+    string PinnedRevision,
+    ChatTemplate Template = ChatTemplate.Phi3);
 
 public class OnnxModelManager
 {
@@ -21,17 +24,19 @@ public class OnnxModelManager
             "microsoft/Phi-3-mini-4k-instruct-onnx",
             "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
             2_725_535_000L,
-            "4afb4415e36dbe8f2a1165e30ac4e4b10d2f29dd"),
+            "5f5f794c1c23c9d5ee142af85df02a6cc52d6945"),
         new("llama-3.2-1b-int4", "Llama 3.2 1B INT4 (1.7 GB)",
             "onnx-community/Llama-3.2-1B-Instruct-GENAI-ONNX",
             "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
             1_866_090_000L,
-            "e983c740a38fcfa57fb4d124b18b644974c3d966"),
+            "e983c740a38fcfa57fb4d124b18b644974c3d966",
+            ChatTemplate.Llama3),
         new("llama-3.2-3b-int4", "Llama 3.2 3B INT4 (3.4 GB)",
             "onnx-community/Llama-3.2-3B-Instruct-GENAI-ONNX",
             "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
             3_661_007_000L,
-            "5db5cdb5b0c8c440264ca0f16f5ec3351e753add")
+            "5db5cdb5b0c8c440264ca0f16f5ec3351e753add",
+            ChatTemplate.Llama3)
     ];
 
     public static string GetModelDirectory(string modelId)

--- a/procrastinate.csproj
+++ b/procrastinate.csproj
@@ -79,7 +79,7 @@
 		<PackageReference Include="Microsoft.Maui.Essentials.AI" Version="10.0.50-ci.main.26126.2" />
 		<PackageReference Include="Microsoft.Extensions.AI" Version="10.0.0" />
 		<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.0.0-preview.1.25559.3" />
-		<PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.12.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'ios'" />
+		<PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.12.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 		<PackageReference Include="Plugin.Maui.Audio" Version="4.0.0" />
 	</ItemGroup>
@@ -93,6 +93,31 @@
 			<DependentUpon>AppResources.resx</DependentUpon>
 		</EmbeddedResource>
 	</ItemGroup>
+
+	<!-- ONNX Runtime native references for iOS (packages target net9.0-ios, needs manual ref for net10.0-ios) -->
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' AND ('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
+		<NativeReference Include="$(NuGetPackageRoot)microsoft.ml.onnxruntime/1.24.1/runtimes/ios/native/onnxruntime.xcframework.zip">
+			<Kind>Static</Kind>
+			<IsCxx>True</IsCxx>
+			<SmartLink>True</SmartLink>
+			<ForceLoad>True</ForceLoad>
+			<LinkerFlags>-lc++</LinkerFlags>
+			<WeakFrameworks>CoreML</WeakFrameworks>
+		</NativeReference>
+		<NativeReference Include="$(NuGetPackageRoot)microsoft.ml.onnxruntimegenai/0.12.2/runtimes/ios/native/onnxruntime-genai.xcframework.zip">
+			<Kind>Static</Kind>
+			<IsCxx>True</IsCxx>
+			<SmartLink>True</SmartLink>
+			<ForceLoad>True</ForceLoad>
+			<LinkerFlags>-lc++</LinkerFlags>
+			<WeakFrameworks>CoreML</WeakFrameworks>
+		</NativeReference>
+	</ItemGroup>
+
+	<!-- ORT custom ops stub required for static linking on iOS -->
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+		<MtouchExtraArgs>$(MtouchExtraArgs) --gcc_flags "-x c Platforms/iOS/OrtExtensionsStub.c"</MtouchExtraArgs>
+	</PropertyGroup>
 
 	<!-- iOS signing configuration -->
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">


### PR DESCRIPTION
## Summary

Adds Llama 3.2 1B and 3B model support across both cloud (Groq) and embedded (ONNX) inference modes.

### Changes

**Cloud (Groq)**
- Added `llama-3.2-3b-preview` and `llama-3.2-1b-preview` to the Groq model picker

**Embedded (ONNX)**
- Added Llama 3.2 1B INT4 (1.7 GB) and 3B INT4 (3.4 GB) from `onnx-community` on HuggingFace
- Refactored `OnnxModelInfo` to include per-model `PinnedRevision` for reproducible downloads
- Added embedded ONNX model picker in Settings UI (replaces hardcoded single model)
- `EmbeddedModelExcuseGenerator` reads selected model from Preferences

### Files Changed
- `Services/OnnxModelManager.cs` — New model entries + per-model revision
- `Services/EmbeddedModelExcuseGenerator.cs` — Reads selected model from Preferences
- `Pages/SettingsPage.xaml` — Model picker UI
- `Pages/SettingsPage.xaml.cs` — Picker logic + dynamic status updates